### PR TITLE
Add Edge Control board to CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -24,7 +24,8 @@ jobs:
 
     env:
       # sketch paths to compile (recursive) compatible with all boards
-      UNIVERSAL_SKETCH_PATHS: '"libraries/Scheduler"'
+      UNIVERSAL_SKETCH_PATHS: |
+        - libraries/Scheduler
 
     strategy:
       fail-fast: false
@@ -39,13 +40,27 @@ jobs:
         include:
           - board:
               fqbn: arduino:mbed:nano33ble
-            additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
+            additional-sketch-paths: |
+              - libraries/PDM
+              - libraries/ThreadDebug
           - board:
               fqbn: arduino:mbed:envie_m4
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_Video"'
+            additional-sketch-paths: |
+              - libraries/doom
+              - libraries/KernelDebug
+              - libraries/Portenta_SDCARD
+              - libraries/Portenta_Video
           - board:
               fqbn: arduino:mbed:envie_m7
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST" "libraries/WiFi"'
+            additional-sketch-paths: |
+              - libraries/doom
+              - libraries/KernelDebug
+              - libraries/Portenta_SDCARD
+              - libraries/Portenta_System
+              - libraries/Portenta_Video
+              - libraries/ThreadDebug
+              - libraries/USBHOST
+              - libraries/WiFi
 
     steps:
       - name: Checkout repository
@@ -75,7 +90,9 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:mbed"
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.additional-sketch-paths }}
           verbose: 'false'
           enable-size-deltas-report: true
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,7 +25,10 @@ jobs:
     env:
       # sketch paths to compile (recursive) compatible with all boards
       UNIVERSAL_SKETCH_PATHS: |
-        - libraries/Scheduler
+        - extras/arduino-examples/examples/01.Basics/Fade
+        - extras/arduino-examples/examples/02.Digital/DigitalInputPullup
+        - extras/arduino-examples/examples/03.Analog/AnalogInput
+        - extras/arduino-examples/examples/04.Communication/MultiSerial
 
     strategy:
       fail-fast: false
@@ -35,6 +38,7 @@ jobs:
           - fqbn: arduino:mbed:nano33ble
           - fqbn: arduino:mbed:envie_m4
           - fqbn: arduino:mbed:envie_m7
+          - fqbn: arduino:mbed:edge_control
 
         # compile only the examples compatible with each board
         include:
@@ -42,6 +46,11 @@ jobs:
               fqbn: arduino:mbed:nano33ble
             additional-sketch-paths: |
               - libraries/PDM
+              - libraries/Scheduler
+              - libraries/ThreadDebug
+          - board:
+              fqbn: arduino:mbed:edge_control
+            additional-sketch-paths: |
               - libraries/ThreadDebug
           - board:
               fqbn: arduino:mbed:envie_m4
@@ -50,6 +59,7 @@ jobs:
               - libraries/KernelDebug
               - libraries/Portenta_SDCARD
               - libraries/Portenta_Video
+              - libraries/Scheduler
           - board:
               fqbn: arduino:mbed:envie_m7
             additional-sketch-paths: |
@@ -58,6 +68,7 @@ jobs:
               - libraries/Portenta_SDCARD
               - libraries/Portenta_System
               - libraries/Portenta_Video
+              - libraries/Scheduler
               - libraries/ThreadDebug
               - libraries/USBHOST
               - libraries/WiFi
@@ -79,6 +90,12 @@ jobs:
 
       - name: Install ArduinoCore-API
         run: mv "$GITHUB_WORKSPACE/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
+
+      - name: Checkout built-in examples
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/arduino-examples
+          path: extras/arduino-examples
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master


### PR DESCRIPTION
Because none of the examples of the platform bundled libraries are really suitable for this board, I added some
compilations of representative built-in example sketches to provide a basic smoke test for the board.

I wasn't sure how many of these basic example sketches are wanted so I kept it pretty minimal. I'm happy to add more if you think they would improve test coverage. The available selection is here:
https://github.com/arduino/arduino-examples/tree/main/examples
One thing to consider is that these compilations are also used to determine impact on memory usage caused by changes to the code, so it's not only "compiles/doesn't compile" information we gain from compiling the sketches.

Because the workflow was configured to compile the ThreadDebug library's examples for the Nano 33 BLE board, I did the same for the Edge Control.

The workflow run is here:
https://github.com/per1234/ArduinoCore-mbed/runs/1213168107?check_suite_focus=true